### PR TITLE
Add startActive prop

### DIFF
--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -17,6 +17,9 @@ export default {
   replace: true,
   name: 'vue-draggable-resizable',
   props: {
+    startActive: {
+      type: Boolean, default: false
+    },
     draggable: {
       type: Boolean, default: true
     },
@@ -152,7 +155,7 @@ export default {
       height: this.h,
       resizing: false,
       dragging: false,
-      active: false,
+      active: this.startActive,
       handle: null,
       zIndex: 1
     }


### PR DESCRIPTION
Hi there,

I wanted to use the vue-draggable-resizable component but I needed it to start active rather than having to click on it to activate. I added a `startActive` property that can be passed in for this behaviour. The default behaviour is the same as before.

It's a pretty trivial change so I just made a PR rather than opening an issue for discussion first. Hope that's cool. It's fine if this is out of scope for the project, or let me know if you'd like any changes to get it merged.

Thanks for the handy component!