### PR TITLE
Do not add a document-level mouse event listener for each draggable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,12 @@
 <template>
   <div id="app">
     <div style="height: 500px; width: 500px; margin: 20px; border: 1px solid red; position: relative;">
-      <VueDraggableResizable :x="50" :y="50" :w="400" :h="400" :parent="true">
+      <VueDraggableResizable :x="50" :y="50" :w="200" :h="200" :parent="true">
         <p>Component</p>
+      </VueDraggableResizable>
+
+      <VueDraggableResizable :x="250" :y="250" :w="400" :h="400" :parent="true">
+        <p>Component2</p>
       </VueDraggableResizable>
     </div>
   </div>


### PR DESCRIPTION
Instead, use a global set of listeners that routes events to the currently dragged item. This should improve performance when there are a lot of draggables. The `current` variable stores a reference to the currently dragging component.