### PR TITLE
Solve Right Click Bug

### DIFF
--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -316,6 +316,7 @@ export default {
       this.elementDown(e)
     },
     elementDown (e) {
+      if(e.which !== 1) return;
       const target = e.target || e.srcElement
 
       if (this.$el.contains(target)) {


### PR DESCRIPTION
if the user clicks right click instead of left click them the browser will open the context menu after closing it the modal will stuck with the user mouse until he clicks left click again