### PR TITLE
Bugfix/lock aspect ratio sizing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <div style="height: 500px; width: 500px; border: 1px solid red; position: relative;">
-      <vue-draggable-resizable :w="400" :h="400" :parent="true" :min-width="200" :min-height="200">
+      <vue-draggable-resizable :w="400" :h="400" :parent="true" :min-width="200" :min-height="200" :lockAspectRatio="true">
         <p>vue-draggable-resizable</p>
       </vue-draggable-resizable>
     </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <div style="height: 500px; width: 500px; border: 1px solid red; position: relative;">
-      <vue-draggable-resizable :w="400" :h="400" :parent="true" :min-width="200" :min-height="200" :lockAspectRatio="true">
+      <vue-draggable-resizable :w="400" :h="400" :parent="true" :min-width="200" :min-height="200">
         <p>vue-draggable-resizable</p>
       </vue-draggable-resizable>
     </div>

--- a/src/utils/fns.js
+++ b/src/utils/fns.js
@@ -37,3 +37,15 @@ export function restrictToBounds (value, min, max) {
 
   return value
 }
+
+export function between (value, min, max) {
+  return value >= min && value <= max
+}
+
+export function subtractPaddings (len, startPadding, endPadding) {
+  return len - startPadding - endPadding
+}
+
+export function scaledDifference (value, opposite, scale) {
+  return opposite * scale - value
+}


### PR DESCRIPTION
Fix of resizing with :lockAspectRatio="true", when handle-bl expands to left-top and handle-tr expands to right-bottom. Now, all corner handles works correctly.

Issue: https://github.com/mauricius/vue-draggable-resizable/issues/250