### PR TITLE
Using the new JS API with ResizeObserver to detect parent resize

### DIFF
--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -256,7 +256,9 @@ export default {
       dragging: false,
       dragEnable: false,
       resizeEnable: false,
-      zIndex: this.z
+      zIndex: this.z,
+
+      parentResizeObserver: null
     }
   },
 
@@ -295,7 +297,13 @@ export default {
     addEvent(document.documentElement, 'mousedown', this.deselect)
     addEvent(document.documentElement, 'touchend touchcancel', this.deselect)
 
-    addEvent(window, 'resize', this.checkParentSize)
+    if ('ResizeObserver' in window) {
+        this.parentResizeObserver = new ResizeObserver(() => this.checkParentSize())
+		this.parentResizeObserver.observe(this.$el.parentNode)
+    } else {
+        // Fallback to standard event listener
+        addEvent(window, 'resize', this.checkParentSize)
+    }
   },
   beforeDestroy: function () {
     removeEvent(document.documentElement, 'mousedown', this.deselect)
@@ -305,7 +313,11 @@ export default {
     removeEvent(document.documentElement, 'mouseup', this.handleUp)
     removeEvent(document.documentElement, 'touchend touchcancel', this.deselect)
 
-    removeEvent(window, 'resize', this.checkParentSize)
+    if (this.parentResizeObserver) {
+        this.parentResizeObserver.disconnect()
+    } else {
+        removeEvent(window, 'resize', this.checkParentSize)
+    }
   },
 
   methods: {


### PR DESCRIPTION
I had trouble with the parent resize,  windows was sometimes dragged outside the parent limits, i am using it in my 3D viewer for the GUI, no problem since i implemented the ResizeObserver