### PR TITLE
Update README.md - Correct spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ Parameters:
 Called whenever the component stops getting resized.
 
 ```html
-<vue-draggable-resizable @resizestop="onResizstop">
+<vue-draggable-resizable @resizestop="onResizestop">
 ```
 
 #### dragging


### PR DESCRIPTION
Tiny PR:

- Correct spelling of `resizstop` to `resizestop` (with an 'e') in README.md